### PR TITLE
Handle lcm(0,0)

### DIFF
--- a/mom/math.py
+++ b/mom/math.py
@@ -83,7 +83,7 @@ def lcm(num_a, num_b):
   :returns:
       Least common multiple.
   """
-  return (num_a * num_b) // gcd(num_a, num_b)
+  return num_a * num_b or (num_a * num_b) // gcd(num_a, num_b)
 
 
 def inverse_mod(num_a, num_b):


### PR DESCRIPTION
Wikipedia (https://en.wikipedia.org/wiki/Least_common_multiple) suggests:

> Since division of integers by zero is undefined, this definition has meaning
> only if a and b are both different from zero. However, some authors define
> lcm(a,0) as 0 for all a, which is the result of taking the lcm to be the least
> upper bound in the lattice of divisibility.
